### PR TITLE
Deduplicate map marker messages

### DIFF
--- a/cTabIRL/cTabRecordingAnalyzer/Program.cs
+++ b/cTabIRL/cTabRecordingAnalyzer/Program.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 // ---------------------------------------------------------------------------
 // cTab Recording Analyzer
@@ -69,7 +70,7 @@ var rateLimitMs = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCas
 {
     ["SetPosition"]           = 1_000,
     ["UpdateMarkersPosition"] = 1_000,
-    ["UpdateMapMarkers"]      = 5_000,
+    ["UpdateMapMarkers"]      = 1_000,
 };
 // Types whose last event is updated in-place rather than dropped
 var keepLatest = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "UpdateMapMarkers" };
@@ -86,6 +87,19 @@ var rateLimitStats          = new Dictionary<string, RateLimitStats>(StringCompa
 var lastTimestampByType     = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
 long exactDroppedBytes      = 0;  // raw JSON bytes of events that are silently discarded
 long exactUpdatedBytes      = 0;  // raw JSON bytes of events whose data is merged in-place (not re-added to list)
+
+// Pattern to strip the legacy data.timestamp field before content comparison
+var dedupNormPattern        = new Regex(@"""timestamp""\s*:\s*""[^""]*""");
+string? lastUpdateMapMarkersNorm = null;
+int  dedupTotal             = 0;
+int  dedupDropped           = 0;
+long dedupDroppedBytes      = 0;
+
+// Combined (dedup → rate-limit) simulation for UpdateMapMarkers
+double? comboLastTs         = null;  // timestamp of the last event that opened a new rate-limit window
+int     comboRlUpdated      = 0;     // passed dedup, within rate-limit window → data updated in-place
+int     comboKept           = 0;     // passed dedup and rate limit → new recording entry
+long    comboRlUpdatedBytes = 0;     // exact bytes of combo rate-limited events
 
 // ---- Walk events ----------------------------------------------------------
 foreach (var evt in root.GetProperty("events").EnumerateArray())
@@ -151,6 +165,40 @@ foreach (var evt in root.GetProperty("events").EnumerateArray())
         {
             stats.Kept++;
             lastTimestampByType[type] = tsMs.Value;
+        }
+    }
+
+    // ---- Simulate content-based deduplication of UpdateMapMarkers ----------
+    if (string.Equals(type, "UpdateMapMarkers", StringComparison.OrdinalIgnoreCase))
+    {
+        dedupTotal++;
+        // Normalise: get data JSON and strip the timestamp field (legacy format)
+        // so that two events with identical map markers but different timestamps compare equal.
+        var dataNorm    = evt.TryGetProperty("data", out var dedupData)
+            ? dedupNormPattern.Replace(dedupData.GetRawText(), "")
+            : "";
+        var evtRawBytes = (long)Encoding.UTF8.GetByteCount(evt.GetRawText());
+
+        if (dataNorm == lastUpdateMapMarkersNorm)
+        {
+            // Dedup hit: skip entirely, never reaches rate limiting
+            dedupDropped++;
+            dedupDroppedBytes += evtRawBytes;
+        }
+        else
+        {
+            lastUpdateMapMarkersNorm = dataNorm;
+            // Combined: event passed dedup → now apply rate-limit on top
+            if (tsMs.HasValue && comboLastTs.HasValue && (tsMs.Value - comboLastTs.Value) < rateLimitMs["UpdateMapMarkers"])
+            {
+                comboRlUpdated++;           // data updated in-place, no new recording entry
+                comboRlUpdatedBytes += evtRawBytes;
+            }
+            else
+            {
+                comboKept++;                // new recording entry
+                if (tsMs.HasValue) { comboLastTs = tsMs.Value; }
+            }
         }
     }
 }
@@ -233,6 +281,64 @@ if (totalDroppedRl + totalUpdatedRl > 0)
 }
 
 Console.WriteLine();
+
+// ---- Report: content-based deduplication of UpdateMapMarkers -------------
+Console.WriteLine("## UpdateMapMarkers Deduplication Simulation");
+Console.WriteLine();
+Console.WriteLine("Mirrors the equality check added to `CTabHub`: an event whose `data` is identical");
+Console.WriteLine("to the previous `UpdateMapMarkers` event is skipped entirely (not recorded).");
+Console.WriteLine();
+Console.WriteLine("| Description | Count | % of Total |" );
+Console.WriteLine("|-------------|------:|-----------:|" );
+Console.WriteLine($"| Total UpdateMapMarkers events    | {dedupTotal:N0}   | |");
+Console.WriteLine($"| Unique (would be emitted)        | {dedupTotal - dedupDropped:N0}   | {(dedupTotal > 0 ? (double)(dedupTotal - dedupDropped) / dedupTotal : 0):P1} |");
+Console.WriteLine($"| Duplicate (would be skipped)     | {dedupDropped:N0}   | {(dedupTotal > 0 ? (double)dedupDropped / dedupTotal : 0):P1} |");
+Console.WriteLine();
+if (dedupDropped > 0)
+{
+    Console.WriteLine("### Byte Savings from Deduplication");
+    Console.WriteLine();
+    Console.WriteLine("| Description | Bytes | % of File |");
+    Console.WriteLine("|-------------|------:|----------:|");
+    Console.WriteLine($"| Exact JSON bytes of duplicate events | {dedupDroppedBytes:N0} | {(double)dedupDroppedBytes / fileSize:P2} |");
+    Console.WriteLine();
+    Console.WriteLine("> Array separators (~2 bytes/event) excluded; actual savings slightly higher.");
+    Console.WriteLine();
+}
+
+// ---- Report: combined effect (UpdateMapMarkers only) ---------------------
+if (dedupTotal > 0)
+{
+    var rlStats = rateLimitStats.GetValueOrDefault("UpdateMapMarkers");
+
+    // Events not tracked by the rate-limit sim (no timestamp) always become new entries
+    int rlTracked      = rlStats != null ? rlStats.Kept + rlStats.Updated : 0;
+    int rlNewEntries   = (rlStats?.Kept ?? 0) + (dedupTotal - rlTracked);
+    long rlSavedBytes  = exactUpdatedBytes;  // UpdateMapMarkers is the only keepLatest type
+
+    int  dedupNewEntries  = dedupTotal - dedupDropped;
+
+    int  comboTracked     = comboKept + comboRlUpdated;
+    int  comboNewEntries  = comboKept + (dedupNewEntries - comboTracked); // +untracked (no timestamp)
+    long comboSavedBytes  = dedupDroppedBytes + comboRlUpdatedBytes;
+
+    Console.WriteLine("## Combined Effect: Rate Limiting + Deduplication (UpdateMapMarkers)");
+    Console.WriteLine();
+    Console.WriteLine("Recording-entry count and exact byte savings for each combination of the two optimisations.");
+    Console.WriteLine();
+    Console.WriteLine("| Scenario | New recording entries | vs No Opt | Bytes saved | % of File |");
+    Console.WriteLine("|----------|----------------------:|----------:|------------:|----------:|");
+    Console.WriteLine($"| No optimisation                   | {dedupTotal:N0} | — | 0 | 0.00 % |");
+    Console.WriteLine($"| Rate limiting only ({rateLimitMs["UpdateMapMarkers"]/1000.0:N1} s window) | {rlNewEntries:N0} | {(double)(dedupTotal - rlNewEntries) / dedupTotal:P1} | {rlSavedBytes:N0} | {(double)rlSavedBytes / fileSize:P2} |");
+    Console.WriteLine($"| Deduplication only (content)      | {dedupNewEntries:N0} | {(double)dedupDropped / dedupTotal:P1} | {dedupDroppedBytes:N0} | {(double)dedupDroppedBytes / fileSize:P2} |");
+    Console.WriteLine($"| Both (dedup first → rate limit)   | {comboNewEntries:N0} | {(double)(dedupTotal - comboNewEntries) / dedupTotal:P1} | {comboSavedBytes:N0} | {(double)comboSavedBytes / fileSize:P2} |");
+    Console.WriteLine();
+    Console.WriteLine("> **New recording entries** = distinct slots added to the recording array.");
+    Console.WriteLine("> In rate-limit mode, within-window events update the last slot in-place (no new entry).");
+    Console.WriteLine("> **Bytes saved** = exact JSON bytes of events not written as new recording entries.");
+    Console.WriteLine();
+}
+
 Console.WriteLine("---");
 Console.WriteLine();
 Console.WriteLine("- **Kept** = first event in the window, written to the recording list");

--- a/cTabIRL/cTabRecordingAnalyzer/Program.cs
+++ b/cTabIRL/cTabRecordingAnalyzer/Program.cs
@@ -15,7 +15,7 @@ using System.Text.RegularExpressions;
 //  4. Rate-limiting simulation that mirrors ActiveRecording.Append logic:
 //       SetPosition           1 s → drop
 //       UpdateMarkersPosition 1 s → drop
-//       UpdateMapMarkers      5 s → update-in-place (keep-latest)
+//       UpdateMapMarkers      1 s → update-in-place (keep-latest)
 // ---------------------------------------------------------------------------
 
 CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;

--- a/cTabIRL/cTabWebApp/Hub/CTabHub.cs
+++ b/cTabIRL/cTabWebApp/Hub/CTabHub.cs
@@ -392,6 +392,13 @@ namespace cTabWebApp
                 });
             }
 
+            if (msg.Equals(state.LastUpdateMapMarkers))
+            {
+                // Arma can send many times the same map markers due to the limited checking it does on its side (performance concerns) 
+                // Avoid sending to web (and recording) if not changed
+                return;
+            }
+
             msg.Timestamp = message.Timestamp;
             state.LastUpdateMapMarkers = msg;
             try

--- a/cTabIRL/cTabWebApp/Hub/IconMapMarker.cs
+++ b/cTabIRL/cTabWebApp/Hub/IconMapMarker.cs
@@ -1,11 +1,37 @@
-﻿namespace cTabWebApp
+﻿using System;
+using System.Linq;
+
+namespace cTabWebApp
 {
-    public class IconMapMarker : MapMarkerBase
+    public class IconMapMarker : MapMarkerBase, IEquatable<IconMapMarker>
     {
         public double[] Pos { get; internal set; }
         public string Icon { get; internal set; }
         public double[] Size { get; internal set; }
         public double Dir { get; internal set; }
         public string Label { get; internal set; }
+
+#nullable enable
+        public bool Equals(IconMapMarker? other)
+        {
+            if (other is null) 
+            { 
+                return false; 
+            }
+
+            return Name == other.Name
+                && Alpha == other.Alpha
+                && Icon == other.Icon
+                && Dir == other.Dir
+                && Label == other.Label
+                && (Pos?.SequenceEqual(other.Pos) ?? other.Pos is null)
+                && (Size?.SequenceEqual(other.Size) ?? other.Size is null);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as IconMapMarker);
+
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Icon, Dir, Label);
+
+#nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/IconMapMarker.cs
+++ b/cTabIRL/cTabWebApp/Hub/IconMapMarker.cs
@@ -30,8 +30,33 @@ namespace cTabWebApp
 
         public override bool Equals(object? obj) => Equals(obj as IconMapMarker);
 
-        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Icon, Dir, Label);
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Name);
+            hash.Add(Alpha);
+            hash.Add(Icon);
+            hash.Add(Dir);
+            hash.Add(Label);
 
+            if (Pos != null)
+            {
+                foreach (var pos in Pos)
+                {
+                    hash.Add(pos);
+                }
+            }
+
+            if (Size != null)
+            {
+                foreach (var size in Size)
+                {
+                    hash.Add(size);
+                }
+            }
+
+            return hash.ToHashCode();
+        }
 #nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/PolylineMapMarker.cs
+++ b/cTabIRL/cTabWebApp/Hub/PolylineMapMarker.cs
@@ -25,7 +25,24 @@ namespace cTabWebApp
 
         public override bool Equals(object? obj) => Equals(obj as PolylineMapMarker);
 
-        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Brush, Color);
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Name);
+            hash.Add(Alpha);
+            hash.Add(Brush);
+            hash.Add(Color);
+
+            if (Points != null)
+            {
+                foreach (var point in Points)
+                {
+                    hash.Add(point);
+                }
+            }
+
+            return hash.ToHashCode();
+        }
 #nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/PolylineMapMarker.cs
+++ b/cTabIRL/cTabWebApp/Hub/PolylineMapMarker.cs
@@ -1,9 +1,31 @@
-﻿namespace cTabWebApp
+﻿using System;
+using System.Linq;
+
+namespace cTabWebApp
 {
-    public class PolylineMapMarker : MapMarkerBase
+    public class PolylineMapMarker : MapMarkerBase, IEquatable<PolylineMapMarker>
     {
         public double[] Points { get; set; }
         public string Brush { get; set; }
         public string Color { get; set; }
+
+#nullable enable
+        public bool Equals(PolylineMapMarker? other)
+        {
+            if (other is null) 
+            { 
+                return false; 
+            }
+            return Name == other.Name
+                && Alpha == other.Alpha
+                && Brush == other.Brush
+                && Color == other.Color
+                && (Points?.SequenceEqual(other.Points) ?? other.Points is null);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as PolylineMapMarker);
+
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Brush, Color);
+#nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/SimpleMapMarker.cs
+++ b/cTabIRL/cTabWebApp/Hub/SimpleMapMarker.cs
@@ -1,6 +1,9 @@
-﻿namespace cTabWebApp
+﻿using System;
+using System.Linq;
+
+namespace cTabWebApp
 {
-    public class SimpleMapMarker : MapMarkerBase
+    public class SimpleMapMarker : MapMarkerBase, IEquatable<SimpleMapMarker>
     {
         public double Dir { get; set; }
         public double[] Size { get; set; }
@@ -8,5 +11,28 @@
         public double[] Pos { get; set; }
         public string Brush { get; set; }
         public string Color { get; set; }
+
+#nullable enable
+        public bool Equals(SimpleMapMarker? other)
+        {
+            if (other is null) 
+            {
+                return false; 
+            }
+            return Name == other.Name
+                && Alpha == other.Alpha
+                && Dir == other.Dir
+                && Shape == other.Shape
+                && Brush == other.Brush
+                && Color == other.Color
+                && (Size?.SequenceEqual(other.Size) ?? other.Size is null)
+                && (Pos?.SequenceEqual(other.Pos) ?? other.Pos is null);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as SimpleMapMarker);
+
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Dir, Shape, Brush, Color);
+
+#nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/SimpleMapMarker.cs
+++ b/cTabIRL/cTabWebApp/Hub/SimpleMapMarker.cs
@@ -31,8 +31,34 @@ namespace cTabWebApp
 
         public override bool Equals(object? obj) => Equals(obj as SimpleMapMarker);
 
-        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Dir, Shape, Brush, Color);
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Name);
+            hash.Add(Alpha);
+            hash.Add(Dir);
+            hash.Add(Shape);
+            hash.Add(Brush);
+            hash.Add(Color);
 
+            if (Size is not null)
+            {
+                foreach (var value in Size)
+                {
+                    hash.Add(value);
+                }
+            }
+
+            if (Pos is not null)
+            {
+                foreach (var value in Pos)
+                {
+                    hash.Add(value);
+                }
+            }
+
+            return hash.ToHashCode();
+        }
 #nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/UpdateMapMarkersMessage.cs
+++ b/cTabIRL/cTabWebApp/Hub/UpdateMapMarkersMessage.cs
@@ -1,12 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace cTabWebApp
 {
-    public class UpdateMapMarkersMessage : RecordableMessageBase
+    public class UpdateMapMarkersMessage : RecordableMessageBase, IEquatable<UpdateMapMarkersMessage>
     {
         public List<SimpleMapMarker> Simples { get; internal set; }
         public List<PolylineMapMarker> Polylines { get; internal set; }
         public List<IconMapMarker> Icons { get; internal set; }
+
+#nullable enable
+        public bool Equals(UpdateMapMarkersMessage? other)
+        {
+            if (other is null) 
+            { 
+                return false; 
+            }
+            return (Simples?.SequenceEqual(other.Simples) ?? other.Simples is null)
+                && (Polylines?.SequenceEqual(other.Polylines) ?? other.Polylines is null)
+                && (Icons?.SequenceEqual(other.Icons) ?? other.Icons is null);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as UpdateMapMarkersMessage);
+
+        public override int GetHashCode() => HashCode.Combine(Simples?.Count, Polylines?.Count, Icons?.Count);
+#nullable disable
     }
 }

--- a/cTabIRL/cTabWebApp/Hub/UpdateMapMarkersMessage.cs
+++ b/cTabIRL/cTabWebApp/Hub/UpdateMapMarkersMessage.cs
@@ -17,9 +17,9 @@ namespace cTabWebApp
             { 
                 return false; 
             }
-            return (Simples?.SequenceEqual(other.Simples) ?? other.Simples is null)
-                && (Polylines?.SequenceEqual(other.Polylines) ?? other.Polylines is null)
-                && (Icons?.SequenceEqual(other.Icons) ?? other.Icons is null);
+            return ((Simples is null && other.Simples is null) || (Simples is not null && other.Simples is not null && Simples.SequenceEqual(other.Simples)))
+                && ((Polylines is null && other.Polylines is null) || (Polylines is not null && other.Polylines is not null && Polylines.SequenceEqual(other.Polylines)))
+                && ((Icons is null && other.Icons is null) || (Icons is not null && other.Icons is not null && Icons.SequenceEqual(other.Icons)));
         }
 
         public override bool Equals(object? obj) => Equals(obj as UpdateMapMarkersMessage);

--- a/cTabIRL/cTabWebApp/Services/Recording/ActiveRecording.cs
+++ b/cTabIRL/cTabWebApp/Services/Recording/ActiveRecording.cs
@@ -19,7 +19,7 @@ namespace cTabWebApp.Services.Recording
             var ticks = new long[Enum.GetValues<EventType>().Length];
             ticks[(int)EventType.SetPosition]           = (long)(1 * Stopwatch.Frequency); // The typical rate of this message is 0.25 sec
             ticks[(int)EventType.UpdateMarkersPosition] = (long)(1 * Stopwatch.Frequency); // The typical rate of this message is 1.5 sec, rate limiting is only a safeguard
-            ticks[(int)EventType.UpdateMapMarkers]      = (long)(5 * Stopwatch.Frequency); // This message is "on demand", but custom scripts can make it really frequent (up to 0.25 sec) and this message is massive 
+            ticks[(int)EventType.UpdateMapMarkers]      = (long)(1 * Stopwatch.Frequency); // This message is "on demand", but custom scripts can make it really frequent (up to 0.25 sec) and this message is massive 
             return ticks;
         }
 

--- a/cTabIRL/cTabWebAppTest/Hub/UpdateMapMarkersMessageTest.cs
+++ b/cTabIRL/cTabWebAppTest/Hub/UpdateMapMarkersMessageTest.cs
@@ -1,0 +1,341 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using cTabWebApp;
+
+namespace cTabWebAppTest.Hub
+{
+    /// <summary>
+    /// Tests for <see cref="UpdateMapMarkersMessage"/> covering value equality
+    /// (<see cref="IEquatable{T}"/>) and the JSON serialisation contract consumed
+    /// by the JS client and the replay engine.
+    /// Production serialisers use PropertyNamingPolicy = CamelCase.
+    /// </summary>
+    public class UpdateMapMarkersMessageTest
+    {
+        private static readonly JsonSerializerOptions Options = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+
+        // ── Test-data factories ───────────────────────────────────────────────
+
+        private static SimpleMapMarker MakeSimple() => new SimpleMapMarker
+        {
+            Name  = "marker1",
+            Alpha = 1.0,
+            Pos   = [100.0, 200.0],
+            Dir   = 45.0,
+            Size  = [2.0, 2.0],
+            Shape = "rectangle",
+            Brush = "solid",
+            Color = "#FF0000"
+        };
+
+        private static PolylineMapMarker MakePolyline() => new PolylineMapMarker
+        {
+            Name   = "poly1",
+            Alpha  = 0.8,
+            Points = [10.0, 20.0, 30.0, 40.0],
+            Brush  = "dashed",
+            Color  = "#00FF00"
+        };
+
+        private static IconMapMarker MakeIcon() => new IconMapMarker
+        {
+            Name  = "icon1",
+            Alpha = 0.5,
+            Pos   = [50.0, 60.0],
+            Icon  = "ColorBlue/hd_kill.png",
+            Size  = [1.5, 1.5],
+            Dir   = 90.0,
+            Label = "Alpha"
+        };
+
+        private static UpdateMapMarkersMessage CreateMessage() => new UpdateMapMarkersMessage
+        {
+            Simples   = [MakeSimple()],
+            Polylines = [MakePolyline()],
+            Icons     = [MakeIcon()]
+        };
+
+        // ── Equality ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Equals_SameInstance_ReturnsTrue()
+        {
+            var msg = CreateMessage();
+
+            Assert.True(msg.Equals(msg));
+        }
+
+        [Fact]
+        public void Equals_Null_ReturnsFalse()
+        {
+            Assert.False(CreateMessage().Equals((UpdateMapMarkersMessage?)null));
+        }
+
+        [Fact]
+        public void Equals_BothEmptyLists_ReturnsTrue()
+        {
+            var a = new UpdateMapMarkersMessage { Simples = [], Polylines = [], Icons = [] };
+            var b = new UpdateMapMarkersMessage { Simples = [], Polylines = [], Icons = [] };
+
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_IdenticalContent_ReturnsTrue()
+        {
+            Assert.True(CreateMessage().Equals(CreateMessage()));
+        }
+
+        [Fact]
+        public void Equals_DifferentSimpleName_ReturnsFalse()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+            b.Simples[0] = new SimpleMapMarker
+            {
+                Name  = "other",
+                Alpha = 1.0,
+                Pos   = [100.0, 200.0],
+                Dir   = 45.0,
+                Size  = [2.0, 2.0],
+                Shape = "rectangle",
+                Brush = "solid",
+                Color = "#FF0000"
+            };
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_DifferentSimplePosArray_ReturnsFalse()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+            b.Simples[0] = new SimpleMapMarker
+            {
+                Name  = "marker1",
+                Alpha = 1.0,
+                Pos   = [999.0, 200.0],  // one coordinate changed
+                Dir   = 45.0,
+                Size  = [2.0, 2.0],
+                Shape = "rectangle",
+                Brush = "solid",
+                Color = "#FF0000"
+            };
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_DifferentPolylinePoints_ReturnsFalse()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+            b.Polylines[0] = new PolylineMapMarker
+            {
+                Name   = "poly1",
+                Alpha  = 0.8,
+                Points = [10.0, 20.0, 30.0, 99.0],  // last point changed
+                Brush  = "dashed",
+                Color  = "#00FF00"
+            };
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_DifferentIconPosArray_ReturnsFalse()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+            b.Icons[0] = new IconMapMarker
+            {
+                Name  = "icon1",
+                Alpha = 0.5,
+                Pos   = [50.0, 99.0],  // Y changed
+                Icon  = "ColorBlue/hd_kill.png",
+                Size  = [1.5, 1.5],
+                Dir   = 90.0,
+                Label = "Alpha"
+            };
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_DifferentIconName_ReturnsFalse()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+            b.Icons[0] = new IconMapMarker
+            {
+                Name  = "icon1",
+                Alpha = 0.5,
+                Pos   = [50.0, 60.0],
+                Icon  = "other.png",
+                Size  = [1.5, 1.5],
+                Dir   = 90.0,
+                Label = "Alpha"
+            };
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_ExtraSimpleInList_ReturnsFalse()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+            b.Simples.Add(MakeSimple());
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_ObjectOverload_Null_ReturnsFalse()
+        {
+            Assert.False(CreateMessage().Equals((object?)null));
+        }
+
+        [Fact]
+        public void Equals_ObjectOverload_WrongType_ReturnsFalse()
+        {
+            Assert.False(CreateMessage().Equals("not a message"));
+        }
+
+        [Fact]
+        public void Equals_ObjectOverload_EqualMessage_ReturnsTrue()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+
+            Assert.True(a.Equals((object)b));
+        }
+
+        [Fact]
+        public void GetHashCode_EqualMessages_ReturnSameValue()
+        {
+            var a = CreateMessage();
+            var b = CreateMessage();
+
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        // ── JSON serialisation ────────────────────────────────────────────────
+
+        [Fact]
+        public void Serialize_EmptyLists_ProducesExactJson()
+        {
+            var msg = new UpdateMapMarkersMessage { Simples = [], Polylines = [], Icons = [] };
+
+            var json = JsonSerializer.Serialize(msg, Options);
+
+            Assert.Equal("{\"simples\":[],\"polylines\":[],\"icons\":[]}", json);
+        }
+
+        [Fact]
+        public void Serialize_TimestampIsIgnored()
+        {
+            var msg = new UpdateMapMarkersMessage { Simples = [], Polylines = [], Icons = [] };
+
+            var json = JsonSerializer.Serialize(msg, Options);
+
+            Assert.DoesNotContain("\"timestamp\"", json);
+            Assert.DoesNotContain("\"Timestamp\"", json);
+        }
+
+        [Fact]
+        public void Serialize_SimpleMapMarker_PropertyNamesAreCamelCase()
+        {
+            var msg = new UpdateMapMarkersMessage
+            {
+                Simples   = [MakeSimple()],
+                Polylines = [],
+                Icons     = []
+            };
+
+            var json = JsonSerializer.Serialize(msg, Options);
+
+            Assert.Contains("\"name\":\"marker1\"",   json);
+            Assert.Contains("\"alpha\":1",            json);
+            Assert.Contains("\"pos\":[100,200]",      json);
+            Assert.Contains("\"dir\":45",             json);
+            Assert.Contains("\"size\":[2,2]",         json);
+            Assert.Contains("\"shape\":\"rectangle\"",json);
+            Assert.Contains("\"brush\":\"solid\"",    json);
+            Assert.Contains("\"color\":\"#FF0000\"",  json);
+            Assert.DoesNotContain("\"Name\"",         json);
+            Assert.DoesNotContain("\"Dir\"",          json);
+            Assert.DoesNotContain("\"Shape\"",        json);
+        }
+
+        [Fact]
+        public void Serialize_PolylineMapMarker_PropertyNamesAreCamelCase()
+        {
+            var msg = new UpdateMapMarkersMessage
+            {
+                Simples   = [],
+                Polylines = [MakePolyline()],
+                Icons     = []
+            };
+
+            var json = JsonSerializer.Serialize(msg, Options);
+
+            Assert.Contains("\"name\":\"poly1\"",          json);
+            Assert.Contains("\"alpha\":0.8",               json);
+            Assert.Contains("\"points\":[10,20,30,40]",    json);
+            Assert.Contains("\"brush\":\"dashed\"",        json);
+            Assert.Contains("\"color\":\"#00FF00\"",       json);
+            Assert.DoesNotContain("\"Points\"",            json);
+            Assert.DoesNotContain("\"Brush\"",             json);
+        }
+
+        [Fact]
+        public void Serialize_IconMapMarker_PropertyNamesAreCamelCase()
+        {
+            var msg = new UpdateMapMarkersMessage
+            {
+                Simples   = [],
+                Polylines = [],
+                Icons     = [MakeIcon()]
+            };
+
+            var json = JsonSerializer.Serialize(msg, Options);
+
+            Assert.Contains("\"name\":\"icon1\"",                    json);
+            Assert.Contains("\"alpha\":0.5",                         json);
+            Assert.Contains("\"pos\":[50,60]",                       json);
+            Assert.Contains("\"icon\":\"ColorBlue/hd_kill.png\"",    json);
+            Assert.Contains("\"size\":[1.5,1.5]",                    json);
+            Assert.Contains("\"dir\":90",                            json);
+            Assert.Contains("\"label\":\"Alpha\"",                   json);
+            Assert.DoesNotContain("\"Icon\"",                        json);
+            Assert.DoesNotContain("\"Label\"",                       json);
+            Assert.DoesNotContain("\"Pos\"",                         json);
+        }
+
+        [Fact]
+        public void Serialize_MultipleMarkersOfEachType_AllItemsAreIncluded()
+        {
+            var msg = new UpdateMapMarkersMessage
+            {
+                Simples   = [MakeSimple(), new SimpleMapMarker { Name = "marker2", Alpha = 0.5, Pos = [1.0, 2.0], Size = [1.0, 1.0], Shape = "ellipse", Dir = 0 }],
+                Polylines = [MakePolyline(), new PolylineMapMarker { Name = "poly2", Alpha = 1.0, Points = [1.0, 2.0], Brush = "solid", Color = "#0000FF" }],
+                Icons     = [MakeIcon(), new IconMapMarker { Name = "icon2", Alpha = 1.0, Pos = [1.0, 2.0], Icon = "other.png", Size = [1.0, 1.0], Dir = 0, Label = "B" }]
+            };
+
+            var json = JsonSerializer.Serialize(msg, Options);
+
+            Assert.Contains("\"marker1\"", json);
+            Assert.Contains("\"marker2\"", json);
+            Assert.Contains("\"poly1\"",   json);
+            Assert.Contains("\"poly2\"",   json);
+            Assert.Contains("\"icon1\"",   json);
+            Assert.Contains("\"icon2\"",   json);
+        }
+    }
+}


### PR DESCRIPTION
Deduplicate map marker messages received from Arma. This allows to reduce time window of rate limiting.

## UpdateMapMarkers Deduplication Simulation

Mirrors the equality check added to `CTabHub`: an event whose `data` is identical
to the previous `UpdateMapMarkers` event is skipped entirely (not recorded).

| Description | Count | % of Total |
|-------------|------:|-----------:|
| Total UpdateMapMarkers events    | 13,913   | |
| Unique (would be emitted)        | 270   | 1.9 % |
| Duplicate (would be skipped)     | 13,643   | 98.1 % |

### Byte Savings from Deduplication

| Description | Bytes | % of File |
|-------------|------:|----------:|
| Exact JSON bytes of duplicate events | 506,145,289 | 95.88 % |

> Array separators (~2 bytes/event) excluded; actual savings slightly higher.

## Combined Effect: Rate Limiting + Deduplication (UpdateMapMarkers)

Recording-entry count and exact byte savings for each combination of the two optimisations.

| Scenario | New recording entries | vs No Opt | Bytes saved | % of File |
|----------|----------------------:|----------:|------------:|----------:|
| No optimisation                   | 13,913 | - | 0 | 0.00 % |
| Rate limiting only (1.0 s window) | 5,390 | 61.3 % | 317,217,875 | 60.09 % |
| Deduplication only (content)      | 270 | 98.1 % | 506,145,289 | 95.88 % |
| Both (dedup first ␦ rate limit)   | 183 | 98.7 % | 509,792,506 | 96.57 % |

> **New recording entries** = distinct slots added to the recording array.
> In rate-limit mode, within-window events update the last slot in-place (no new entry).
> **Bytes saved** = exact JSON bytes of events not written as new recording entries.